### PR TITLE
Make the Argon2 and Blake2 projects cross compile for net461

### DIFF
--- a/Konscious.Security.Cryptography.Argon2.Test/project.json
+++ b/Konscious.Security.Cryptography.Argon2.Test/project.json
@@ -35,6 +35,8 @@
         "dnxcore50",
         "portable-net45+win8"
       ]
+    },
+    "net461": {
     }
   }
 }

--- a/Konscious.Security.Cryptography.Argon2/project.json
+++ b/Konscious.Security.Cryptography.Argon2/project.json
@@ -27,6 +27,8 @@
         }
       },
       "imports": "dnxcore50"
+    },
+    "net461": {
     }
   }
 }

--- a/Konscious.Security.Cryptography.Blake2.Test/project.json
+++ b/Konscious.Security.Cryptography.Blake2.Test/project.json
@@ -35,6 +35,8 @@
         "dnxcore50",
         "portable-net45+win8"
       ]
+    },
+    "net461": {
     }
   }
 }

--- a/Konscious.Security.Cryptography.Blake2/HMACBlake2B.cs
+++ b/Konscious.Security.Cryptography.Blake2/HMACBlake2B.cs
@@ -77,6 +77,10 @@ namespace Konscious.Security.Cryptography
         {
             get
             {
+#if NET461
+                if (KeyValue == null)
+                    return null;
+#endif
                 return base.Key;
             }
 

--- a/Konscious.Security.Cryptography.Blake2/project.json
+++ b/Konscious.Security.Cryptography.Blake2/project.json
@@ -26,6 +26,11 @@
         }
       },
       "imports": "dnxcore50"
+    },
+    "net461": {
+      "dependencies": {
+        "System.Numerics.Vectors": "4.1.1"
+      }
     }
   }
 }


### PR DESCRIPTION
I'd like to propose the addition of `net461` as an additional build target as the code base already appears to essentially work as-is across both `netcoreapp1.0` and `net461`.

The problem I did encounter was that `HMAC.Key` in `net461` throws when there is no key set, hence the additional null check on `HMAC.KeyValue`.