### PR TITLE
Set ConfigureAwait to false in order to prevent blocking code

### DIFF
--- a/Konscious.Security.Cryptography.Argon2/Argon2Core.cs
+++ b/Konscious.Security.Cryptography.Argon2/Argon2Core.cs
@@ -31,7 +31,7 @@ namespace Konscious.Security.Cryptography
         // private stuff starts here
         internal async Task<byte[]> Hash(byte[] password)
         {
-            var lanes = await InitializeLanes(password);
+            var lanes = await InitializeLanes(password).ConfigureAwait(false);
 
             var start = 2;
             for (var i = 0; i < Iterations; ++i)
@@ -71,7 +71,7 @@ namespace Konscious.Security.Cryptography
                         }
                     }));
 
-                    await Task.WhenAll(segment);
+                    await Task.WhenAll(segment).ConfigureAwait(false);
                     start = 0;
                 }
             }


### PR DESCRIPTION
We had a problem using the library in our website, it resulted in blocking code.
Setting ConfigureAwait to false should eliminate this problem.

For more details see: 
https://msdn.microsoft.com/en-us/magazine/jj991977.aspx