### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ or
 ```C#
 var argon2 = new Argon2d(password);
 ```
-
+or
+```C#
+var argon2 = new Argon2id(password);
+```
 Various attributes can be added to secure the hash:
 
 | Property           | Type      | Required?   |    Description


### PR DESCRIPTION
Clarify that the Argon2id constructor is also available, not just the -i and -d variants.
This was not obvious to me or coworkers at first.