### PR TITLE
🕸️ Add .NET 10 target.

### DIFF
--- a/ArgonBenchmarks/ArgonBenchmarks.csproj
+++ b/ArgonBenchmarks/ArgonBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0;net8.0;net10.0</TargetFrameworks>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/ComparisonHarness/ComparisonHarness.csproj
+++ b/ComparisonHarness/ComparisonHarness.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Konscious.Security.Cryptography.Argon2.Test/Konscious.Security.Cryptography.Argon2.Test.csproj
+++ b/Konscious.Security.Cryptography.Argon2.Test/Konscious.Security.Cryptography.Argon2.Test.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <PackageId>Konscious.Security.Cryptography.Argon2.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <TargetFrameworks>net5;net8.0</TargetFrameworks>
+    <TargetFrameworks>net5;net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Konscious.Security.Cryptography.Argon2/Konscious.Security.Cryptography.Argon2.csproj" />

--- a/Konscious.Security.Cryptography.Argon2/Konscious.Security.Cryptography.Argon2.csproj
+++ b/Konscious.Security.Cryptography.Argon2/Konscious.Security.Cryptography.Argon2.csproj
@@ -9,7 +9,7 @@ Usage follows standard types found in System.Security.Cryptography in corefx. Sp
 C# Implementation of the Argon2 1.3 spec with variants for Argon2i, Argon2d, and Argon2id
 
       </Description>
-    <Copyright>(c) 2025 Keef Aragon</Copyright>
+    <Copyright>(c) 2026 Keef Aragon</Copyright>
     <AssemblyTitle>Konscious.Security.Cryptography.Argon2</AssemblyTitle>
     <VersionPrefix>1.3.2</VersionPrefix>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Konscious.Security.Cryptography.Argon2/Konscious.Security.Cryptography.Argon2.csproj
+++ b/Konscious.Security.Cryptography.Argon2/Konscious.Security.Cryptography.Argon2.csproj
@@ -9,7 +9,7 @@ Usage follows standard types found in System.Security.Cryptography in corefx. Sp
 C# Implementation of the Argon2 1.3 spec with variants for Argon2i, Argon2d, and Argon2id
 
       </Description>
-    <Copyright>(c) 2026 Keef Aragon</Copyright>
+    <Copyright>(c) 2024 Keef Aragon</Copyright>
     <AssemblyTitle>Konscious.Security.Cryptography.Argon2</AssemblyTitle>
     <VersionPrefix>1.3.2</VersionPrefix>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Konscious.Security.Cryptography.Argon2/Konscious.Security.Cryptography.Argon2.csproj
+++ b/Konscious.Security.Cryptography.Argon2/Konscious.Security.Cryptography.Argon2.csproj
@@ -9,9 +9,9 @@ Usage follows standard types found in System.Security.Cryptography in corefx. Sp
 C# Implementation of the Argon2 1.3 spec with variants for Argon2i, Argon2d, and Argon2id
 
       </Description>
-    <Copyright>(c) 2024 Keef Aragon</Copyright>
+    <Copyright>(c) 2025 Keef Aragon</Copyright>
     <AssemblyTitle>Konscious.Security.Cryptography.Argon2</AssemblyTitle>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.3.2</VersionPrefix>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <Authors>Keef Aragon</Authors>
     <LangVersion>8.0</LangVersion>
@@ -30,9 +30,9 @@ C# Implementation of the Argon2 1.3 spec with variants for Argon2i, Argon2d, and
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1.1</RuntimeFrameworkVersion>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);net46</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
-    <TargetFrameworks>netstandard1.3;net4.6;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net4.6;net6.0;net8.0;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Konscious.Security.Cryptography.Blake2.Test/Konscious.Security.Cryptography.Blake2.Test.csproj
+++ b/Konscious.Security.Cryptography.Blake2.Test/Konscious.Security.Cryptography.Blake2.Test.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Konscious.Security.Cryptography.Blake2.Test</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Konscious.Security.Cryptography.Blake2.Test</PackageId>
-    <TargetFrameworks>net5;net8.0</TargetFrameworks>
+    <TargetFrameworks>net5;net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../Konscious.Security.Cryptography.Blake2/Konscious.Security.Cryptography.Blake2.csproj" />

--- a/Konscious.Security.Cryptography.Blake2/Konscious.Security.Cryptography.Blake2.csproj
+++ b/Konscious.Security.Cryptography.Blake2/Konscious.Security.Cryptography.Blake2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An implementation of Blake2 for .NET that integrates with the standard crypto libraries</Description>
-    <Copyright>(c) 2026 Keef Aragon</Copyright>
+    <Copyright>©️ 2026 Keef Aragon</Copyright>
     <AssemblyTitle>Konscious.Security.Cryptography.Blake2</AssemblyTitle>
     <VersionPrefix>1.1.2</VersionPrefix>
     <Authors>Keef Aragon</Authors>

--- a/Konscious.Security.Cryptography.Blake2/Konscious.Security.Cryptography.Blake2.csproj
+++ b/Konscious.Security.Cryptography.Blake2/Konscious.Security.Cryptography.Blake2.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An implementation of Blake2 for .NET that integrates with the standard crypto libraries</Description>
-    <Copyright>(c) 2024 Keef Aragon</Copyright>
+    <Copyright>(c) 2025 Keef Aragon</Copyright>
     <AssemblyTitle>Konscious.Security.Cryptography.Blake2</AssemblyTitle>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.1.2</VersionPrefix>
     <Authors>Keef Aragon</Authors>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -21,7 +21,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1.1</RuntimeFrameworkVersion>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);net46</PackageTargetFallback>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
-    <TargetFrameworks>netstandard1.3;net46;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net46;net6.0;net8.0;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Version>1.1.1</Version>
   </PropertyGroup>

--- a/Konscious.Security.Cryptography.Blake2/Konscious.Security.Cryptography.Blake2.csproj
+++ b/Konscious.Security.Cryptography.Blake2/Konscious.Security.Cryptography.Blake2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An implementation of Blake2 for .NET that integrates with the standard crypto libraries</Description>
-    <Copyright>(c) 2025 Keef Aragon</Copyright>
+    <Copyright>(c) 2026 Keef Aragon</Copyright>
     <AssemblyTitle>Konscious.Security.Cryptography.Blake2</AssemblyTitle>
     <VersionPrefix>1.1.2</VersionPrefix>
     <Authors>Keef Aragon</Authors>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '1.0.{build}'
+image: Visual Studio 2026
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 version: '1.0.{build}'
 pull_requests:
   do_not_increment_build_number: true
-dotnet_core:
-  version: 10.0.x
 branches:
   only:
   - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: '1.0.{build}'
 pull_requests:
   do_not_increment_build_number: true
+dotnet_core:
+  version: 10.0.x
 branches:
   only:
   - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,10 @@
 version: '1.0.{build}'
 image: Visual Studio 2026
+install:
+  # Download the official .NET install script
+  - ps: Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "dotnet-install.ps1"
+  # Install the .NET 10 SDK directly into the system's dotnet folder
+  - ps: .\dotnet-install.ps1 -Channel 10.0 -InstallDir "C:\Program Files\dotnet"
 pull_requests:
   do_not_increment_build_number: true
 branches:


### PR DESCRIPTION
Looks like appveyor updates version about once a month and they previous missed the .net 10 sdk by a few days: https://www.appveyor.com/updates/

Hopefully the next one will include the .net 10 sdk.